### PR TITLE
Missing classification

### DIFF
--- a/src/CsharpToHtml/ClassTable.cs
+++ b/src/CsharpToHtml/ClassTable.cs
@@ -31,6 +31,7 @@ public class ClassTable
         or "record class name"
         or "record struct name"
         or "type parameter name"
+        or "delegate name"
         => "type",
 
         "string" or "string - verbatim" => "string",

--- a/src/CsharpToHtml/ClassTable.cs
+++ b/src/CsharpToHtml/ClassTable.cs
@@ -22,7 +22,9 @@ public class ClassTable
 
         "keyword - control" => "control",
 
-        "method name" => "method",
+        "method name"
+        or "extension method name"
+        => "method",
 
         "class name"
         or "struct name"


### PR DESCRIPTION
fix https://github.com/ufcpp/RoslynCsharpToHtml/issues/13

I missed "delegate type" and "extension method name".